### PR TITLE
Add FastAPI server and fix setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch
-
-
-
--e .
+fastapi
+uvicorn
+numpy
+scipy
+soundfile

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
 from setuptools import find_packages, setup
 from typing import List
 
-HYPEN_E_DOT = '-e .'
-def get_requirements(file_path:str)->List[str]:
-    '''
-    this function will return a l;ist of all the requirements
-    '''
-    requirements = []
+HYPHEN_E_DOT = "-e ."
+
+
+def get_requirements(file_path: str) -> List[str]:
+    """Return a list of requirements from the given file."""
+
+    requirements: List[str] = []
     with open(file_path) as f:
-        requirements = f.readlines()
-        requiremetns = [req.replace('\n','') for req in requirements]
-    
-        if HYPEN_E_DOT in requirements:
-            requirements.remove(HYPEN_E_DOT)
+        requirements = [req.strip() for req in f.readlines()]
+
+    if HYPHEN_E_DOT in requirements:
+        requirements.remove(HYPHEN_E_DOT)
+
     return requirements
 
 setup(
@@ -21,5 +22,5 @@ setup(
     version='0.1',
     author='Kai',
     packages=find_packages(),
-    install_requires=get_requirements('requirements.txt')
+    install_requires=get_requirements("requirements.txt"),
 )

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import StreamingResponse
+import io
+import soundfile as sf
+
+from .enhancer import enhance_audio
+
+app = FastAPI(title="Speech Enhancement Service")
+
+
+@app.post("/enhance")
+async def enhance(file: UploadFile = File(...)):
+    """Enhance an uploaded WAV file and return the processed audio."""
+    contents = await file.read()
+    data, sr = sf.read(io.BytesIO(contents))
+
+    enhanced = enhance_audio(data.astype(float), sr)
+
+    buf = io.BytesIO()
+    sf.write(buf, enhanced, sr, format="WAV")
+    buf.seek(0)
+    return StreamingResponse(buf, media_type="audio/wav")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/enhancer.py
+++ b/src/enhancer.py
@@ -1,0 +1,18 @@
+import numpy as np
+from scipy.signal import butter, lfilter
+
+
+def highpass_filter(data: np.ndarray, sr: int, cutoff: float = 100.0) -> np.ndarray:
+    """Apply a simple high pass filter for basic noise reduction."""
+    b, a = butter(1, cutoff / (sr / 2), btype="high")
+    return lfilter(b, a, data)
+
+
+def enhance_audio(data: np.ndarray, sr: int) -> np.ndarray:
+    """Enhance the given audio using a naive noise reduction algorithm."""
+    enhanced = highpass_filter(data, sr)
+    # Ensure the signal is within [-1, 1]
+    max_val = np.max(np.abs(enhanced))
+    if max_val > 0:
+        enhanced = enhanced / max_val
+    return enhanced


### PR DESCRIPTION
## Summary
- clean up `setup.py` helper to install requirements
- replace corrupted `requirements.txt` with actual dependencies
- add simple audio enhancement logic
- expose FastAPI service to enhance uploaded audio files

## Testing
- `python -m src.app` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi uvicorn numpy scipy soundfile` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f544fb438832bb25947e8d466561b